### PR TITLE
Create reifyhealth om fork

### DIFF
--- a/src/main/om/next.cljc
+++ b/src/main/om/next.cljc
@@ -284,7 +284,7 @@
 
 #?(:clj
    (defn- proto-assign-impls [env resolve type-sym type [p sigs]]
-     (#'cljs.core/warn-and-update-protocol p type env)
+     (#'cljs.core/update-protocol-var p type env)
      (let [psym      (resolve p)
            pprefix   (#'cljs.core/protocol-prefix psym)
            skip-flag (set (-> type-sym meta :skip-protocol-flag))

--- a/src/main/om/next.cljc
+++ b/src/main/om/next.cljc
@@ -490,7 +490,7 @@
 ;; CLJS
 
 #?(:cljs
-   (defonce *logger*
+   (defonce ^:dynamic *logger*
      (when ^boolean goog.DEBUG
        (.setCapturing (Console.) true)
        (glog/getLogger "om.next"))))


### PR DESCRIPTION
This branch incorporates the change we've been using in salk in production, as well as another fix to address a build warning

See https://github.com/jimberlage-reify/om, the repo where the previous update lived, and https://reify.slack.com/archives/C02JCKA9K9A/p1688396062014419 for the background about migrating to a reifyhealth repo